### PR TITLE
Update tab.R

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+tests/.DS_Store
+
+.DS_Store
+
+.Rhistory

--- a/R/statar.R
+++ b/R/statar.R
@@ -69,6 +69,7 @@
 #' @importFrom matrixStats weightedMean
 #' @importFrom matrixStats colWeightedMeans
 #' @importFrom matrixStats colRanges
+#' @importFrom pander pander
 #' @importFrom parallel mclapply
 #' @importFrom stringr str_replace
 #' @importFrom stringr str_match


### PR DESCRIPTION
1. Fixed small errors in documentation.
2. Added shorter two-way tab() example without using group_by().
3. Changed output column `n’ to `Freq.’ to reflect Stata output.
4. Changed print() to pander() for ASCII formatting in the console to reflect Stata output (more closely).
5. statar.R now requires pander.