### PR TITLE
check duplicates only on selected columns

### DIFF
--- a/R/join.R
+++ b/R/join.R
@@ -74,12 +74,12 @@ join =  function(x, y, kind ,on = intersect(names(x),names(y)), suffixes = c(".x
           out <- merge(x, y, by = NULL)
     } else {
       if (check[[2]] == 1){
-         if (anyDuplicated(x)){ 
+         if (anyDuplicated(x[,vars])){ 
            stop(paste0("Variable(s) ",paste(vars, collapse = " ")," don't uniquely identify observations in x"), call. = FALSE)
          }
        }
       if (check[[3]] == 1){
-       if (anyDuplicated(y)){ 
+       if (anyDuplicated(y[,vars])){ 
          stop(paste0("Variable(s) ",paste(vars, collapse = " ")," don't uniquely identify observations in y"), call. = FALSE)
        }
       }

--- a/tests/testthat/test_join.R
+++ b/tests/testthat/test_join.R
@@ -138,3 +138,13 @@ test_that("if right join, the merge variable should not contain value 1", {
     expect_true(all(unique(m1) %in% c(2L, 3L)))
     expect_true(all(unique(m2) %in% c(2L, 3L)))
 })
+
+# Test the key integrity check -------------------------------------
+
+e <- as.data.frame(c)
+f <- as.data.frame(d)
+
+test_that("the check correctly interprets duplicated identifiers", {
+  expect_error(join(e, f, c("x", "y"), kind = "full", check = 1~m), ".*x$")
+  expect_error(join(e, f, c("x", "y"), kind = "full", check = m~1), ".*y$")
+})


### PR DESCRIPTION
I believe the correct behavior should be to only check for duplicates on selected columns (passed on to "on", then "vars")

Example code which contains duplicated identifiers on the second data.frame, yet doesn't trigger the check stop on a 1~1 merge:

```
a <- data.frame(id = c(1,2,3), av = letters[c(1,2,3)])
b <- data.frame(id = c(2,2,3), bv = letters[c(4,5,6)])

c <- statar::join(a, b, kind = "full", on = "id", check = 1~1, gen = "_m")
```